### PR TITLE
Create-Get-All-Assets

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -17,6 +17,36 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/assets": {
+            "get": {
+                "description": "Get all assets",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Assets"
+                ],
+                "summary": "Get all assets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entity.Asset"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v1.response"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Create and issue a new asset on Stellar",
                 "consumes": [
@@ -363,9 +393,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/role-permission/permissions": {
+            "get": {
+                "description": "Role permissions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "RolePermissions"
+                ],
+                "summary": "Role permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entity.RolePermissionResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user/create": {
             "post": {
-                "description": "Create user",
+                "description": "Edit users role",
                 "consumes": [
                     "application/json"
                 ],
@@ -375,13 +431,13 @@ const docTemplate = `{
                 "tags": [
                     "user"
                 ],
-                "summary": "Create user",
-                "operationId": "create",
+                "summary": "Edit users role",
+                "operationId": "editUsersRole",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v1.userResponse"
+                            "$ref": "#/definitions/entity.UserRole"
                         }
                     },
                     "500": {
@@ -448,6 +504,29 @@ const docTemplate = `{
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/v1.response"
+                        }
+                    }
+                }
+            }
+        },
+        "/users": {
+            "get": {
+                "description": "Get PRofile",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "GET Profile",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entity.UserResponse"
                         }
                     }
                 }
@@ -643,13 +722,26 @@ const docTemplate = `{
                 }
             }
         },
+        "entity.RolePermissionResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Edit action"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Edit"
+                }
+            }
+        },
         "entity.User": {
             "type": "object",
             "properties": {
-                "_": {
+                "created_at": {
                     "type": "string"
                 },
-                "created_at": {
+                "email": {
                     "type": "string"
                 },
                 "id": {
@@ -658,10 +750,50 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "token_hash": {
+                "password": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "token": {
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "entity.UserResponse": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "entity.UserRole": {
+            "type": "object",
+            "properties": {
+                "id_role": {
+                    "type": "string"
+                },
+                "id_user": {
                     "type": "string"
                 }
             }
@@ -839,7 +971,46 @@ const docTemplate = `{
             }
         },
         "v1.UpdateAuthFlagsRequest": {
-            "type": "object"
+            "type": "object",
+            "required": [
+                "code",
+                "issuer",
+                "trustor_id"
+            ],
+            "properties": {
+                "clear_flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[\"AUTH_IMMUTABLE\"]"
+                    ]
+                },
+                "code": {
+                    "type": "string",
+                    "example": "USDC"
+                },
+                "issuer": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "set_flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[\"AUTH_REQUIRED\"",
+                        " \"AUTH_REVOCABLE\"",
+                        "\"AUTH_CLAWBACK_ENABLED\"]"
+                    ]
+                },
+                "trustor_id": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
         },
         "v1.response": {
             "type": "object",
@@ -853,9 +1024,6 @@ const docTemplate = `{
         "v1.userResponse": {
             "type": "object",
             "properties": {
-                "token": {
-                    "type": "string"
-                },
                 "user": {
                     "$ref": "#/definitions/entity.User"
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5,6 +5,36 @@
     },
     "paths": {
         "/assets": {
+            "get": {
+                "description": "Get all assets",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Assets"
+                ],
+                "summary": "Get all assets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entity.Asset"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/v1.response"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Create and issue a new asset on Stellar",
                 "consumes": [
@@ -351,9 +381,35 @@
                 }
             }
         },
+        "/role-permission/permissions": {
+            "get": {
+                "description": "Role permissions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "RolePermissions"
+                ],
+                "summary": "Role permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/entity.RolePermissionResponse"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/user/create": {
             "post": {
-                "description": "Create user",
+                "description": "Edit users role",
                 "consumes": [
                     "application/json"
                 ],
@@ -363,13 +419,13 @@
                 "tags": [
                     "user"
                 ],
-                "summary": "Create user",
-                "operationId": "create",
+                "summary": "Edit users role",
+                "operationId": "editUsersRole",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/v1.userResponse"
+                            "$ref": "#/definitions/entity.UserRole"
                         }
                     },
                     "500": {
@@ -436,6 +492,29 @@
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/v1.response"
+                        }
+                    }
+                }
+            }
+        },
+        "/users": {
+            "get": {
+                "description": "Get PRofile",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "GET Profile",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/entity.UserResponse"
                         }
                     }
                 }
@@ -631,13 +710,26 @@
                 }
             }
         },
+        "entity.RolePermissionResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Edit action"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Edit"
+                }
+            }
+        },
         "entity.User": {
             "type": "object",
             "properties": {
-                "_": {
+                "created_at": {
                     "type": "string"
                 },
-                "created_at": {
+                "email": {
                     "type": "string"
                 },
                 "id": {
@@ -646,10 +738,50 @@
                 "name": {
                     "type": "string"
                 },
-                "token_hash": {
+                "password": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "token": {
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "entity.UserResponse": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "role_id": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "entity.UserRole": {
+            "type": "object",
+            "properties": {
+                "id_role": {
+                    "type": "string"
+                },
+                "id_user": {
                     "type": "string"
                 }
             }
@@ -827,7 +959,46 @@
             }
         },
         "v1.UpdateAuthFlagsRequest": {
-            "type": "object"
+            "type": "object",
+            "required": [
+                "code",
+                "issuer",
+                "trustor_id"
+            ],
+            "properties": {
+                "clear_flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[\"AUTH_IMMUTABLE\"]"
+                    ]
+                },
+                "code": {
+                    "type": "string",
+                    "example": "USDC"
+                },
+                "issuer": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "set_flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[\"AUTH_REQUIRED\"",
+                        " \"AUTH_REVOCABLE\"",
+                        "\"AUTH_CLAWBACK_ENABLED\"]"
+                    ]
+                },
+                "trustor_id": {
+                    "type": "integer",
+                    "example": 2
+                }
+            }
         },
         "v1.response": {
             "type": "object",
@@ -841,9 +1012,6 @@
         "v1.userResponse": {
             "type": "object",
             "properties": {
-                "token": {
-                    "type": "string"
-                },
                 "user": {
                     "$ref": "#/definitions/entity.User"
                 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -39,19 +39,54 @@ definitions:
         example: Admin
         type: string
     type: object
+  entity.RolePermissionResponse:
+    properties:
+      description:
+        example: Edit action
+        type: string
+      name:
+        example: Edit
+        type: string
+    type: object
   entity.User:
     properties:
-      _:
-        type: string
       created_at:
+        type: string
+      email:
         type: string
       id:
         type: string
       name:
         type: string
-      token_hash:
+      password:
+        type: string
+      role_id:
+        type: integer
+      token:
         type: string
       updated_at:
+        type: string
+    type: object
+  entity.UserResponse:
+    properties:
+      email:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      role:
+        type: string
+      role_id:
+        type: integer
+      updated_at:
+        type: string
+    type: object
+  entity.UserRole:
+    properties:
+      id_role:
+        type: string
+      id_user:
         type: string
     type: object
   entity.Wallet:
@@ -179,6 +214,34 @@ definitions:
     - sponsor_id
     type: object
   v1.UpdateAuthFlagsRequest:
+    properties:
+      clear_flags:
+        example:
+        - '["AUTH_IMMUTABLE"]'
+        items:
+          type: string
+        type: array
+      code:
+        example: USDC
+        type: string
+      issuer:
+        example: 2
+        type: integer
+      set_flags:
+        example:
+        - '["AUTH_REQUIRED"'
+        - ' "AUTH_REVOCABLE"'
+        - '"AUTH_CLAWBACK_ENABLED"]'
+        items:
+          type: string
+        type: array
+      trustor_id:
+        example: 2
+        type: integer
+    required:
+    - code
+    - issuer
+    - trustor_id
     type: object
   v1.response:
     properties:
@@ -188,8 +251,6 @@ definitions:
     type: object
   v1.userResponse:
     properties:
-      token:
-        type: string
       user:
         $ref: '#/definitions/entity.User'
     type: object
@@ -197,6 +258,26 @@ info:
   contact: {}
 paths:
   /assets:
+    get:
+      consumes:
+      - application/json
+      description: Get all assets
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/entity.Asset'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.response'
+      summary: Get all assets
+      tags:
+      - Assets
     post:
       consumes:
       - application/json
@@ -423,24 +504,41 @@ paths:
       summary: List
       tags:
       - Role
-  /user/create:
-    post:
+  /role-permission/permissions:
+    get:
       consumes:
       - application/json
-      description: Create user
-      operationId: create
+      description: Role permissions
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/v1.userResponse'
+            items:
+              $ref: '#/definitions/entity.RolePermissionResponse'
+            type: array
+      summary: Role permissions
+      tags:
+      - RolePermissions
+  /user/create:
+    post:
+      consumes:
+      - application/json
+      description: Edit users role
+      operationId: editUsersRole
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entity.UserRole'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/v1.response'
-      summary: Create user
+      summary: Edit users role
       tags:
       - user
   /user/login:
@@ -481,6 +579,21 @@ paths:
           schema:
             $ref: '#/definitions/v1.response'
       summary: Logout User
+      tags:
+      - user
+  /users:
+    get:
+      consumes:
+      - application/json
+      description: Get PRofile
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entity.UserResponse'
+      summary: GET Profile
       tags:
       - user
   /wallets:

--- a/backend/internal/controller/http/v1/assets.go
+++ b/backend/internal/controller/http/v1/assets.go
@@ -21,6 +21,7 @@ func newAssetsRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase, as useca
 	r := &assetsRoutes{w, as, m}
 	h := handler.Group("/assets")
 	{
+		h.GET("", r.getAllAssets)
 		h.POST("", r.createAsset)
 		h.POST("/mint", r.mintAsset)
 		h.POST("/update-auth-flags", r.updateAuthFlags)
@@ -66,7 +67,7 @@ type TransferAssetRequest struct {
 
 type UpdateAuthFlagsRequest struct {
 	TrustorId  int      `json:"trustor_id"       binding:"required"  example:"2"`
-	Issuer     int      `json:"issuer"       binding:"required"  example:"KSJDS..."`
+	Issuer     int      `json:"issuer"       binding:"required"  example:"2"`
 	Code       string   `json:"code"       binding:"required"  example:"USDC"`
 	SetFlags   []string `json:"set_flags"       example:"[\"AUTH_REQUIRED\", \"AUTH_REVOCABLE\",\"AUTH_CLAWBACK_ENABLED\"]"`
 	ClearFlags []string `json:"clear_flags"       example:"[\"AUTH_IMMUTABLE\"]"`
@@ -497,4 +498,22 @@ func (r *assetsRoutes) updateAuthFlags(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "authorization flags updated"})
+}
+
+// @Summary Get all assets
+// @Description Get all assets
+// @Tags  	    Assets
+// @Accept      json
+// @Produce     json
+// @Success     200 {object} []entity.Asset
+// @Failure     500 {object} response
+// @Router      /assets [get]
+func (r *assetsRoutes) getAllAssets(c *gin.Context) {
+	assets, err := r.as.GetAll()
+	if err != nil {
+		errorResponse(c, http.StatusInternalServerError, "error getting assets")
+		return
+	}
+
+	c.JSON(http.StatusOK, assets)
 }

--- a/backend/internal/usecase/assets.go
+++ b/backend/internal/usecase/assets.go
@@ -47,3 +47,12 @@ func (uc *AssetUseCase) Get(code string) (entity.Asset, error) {
 
 	return asset, nil
 }
+
+func (uc *AssetUseCase) GetAll() ([]entity.Asset, error) {
+	assets, err := uc.aRepo.GetAssets()
+	if err != nil {
+		return nil, fmt.Errorf("AssetUseCase - GetAll - uc.repo.GetAssets: %w", err)
+	}
+
+	return assets, nil
+}

--- a/backend/internal/usecase/mocks/mocks.go
+++ b/backend/internal/usecase/mocks/mocks.go
@@ -123,21 +123,6 @@ func (mr *MockUserRepoMockRecorder) GetUserByToken(token interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByToken", reflect.TypeOf((*MockUserRepo)(nil).GetUserByToken), token)
 }
 
-// GetUserByToken mocks base method.
-func (m *MockUserRepo) GetUserByToken(token string) (entity.User, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserByToken", token)
-	ret0, _ := ret[0].(entity.User)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserByToken indicates an expected call of GetUserByToken.
-func (mr *MockUserRepoMockRecorder) GetUserByToken(token interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByToken", reflect.TypeOf((*MockUserRepo)(nil).GetUserByToken), token)
-}
-
 // UpdateToken mocks base method.
 func (m *MockUserRepo) UpdateToken(id, token string) error {
 	m.ctrl.T.Helper()
@@ -442,44 +427,6 @@ func (m *MockAssetRepoInterface) GetAssets() ([]entity.Asset, error) {
 func (mr *MockAssetRepoInterfaceMockRecorder) GetAssets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssets", reflect.TypeOf((*MockAssetRepoInterface)(nil).GetAssets))
-}
-
-// MockRoleRepoInterface is a mock of RoleRepoInterface interface.
-type MockRoleRepoInterface struct {
-	ctrl     *gomock.Controller
-	recorder *MockRoleRepoInterfaceMockRecorder
-}
-
-// MockRoleRepoInterfaceMockRecorder is the mock recorder for MockRoleRepoInterface.
-type MockRoleRepoInterfaceMockRecorder struct {
-	mock *MockRoleRepoInterface
-}
-
-// NewMockRoleRepoInterface creates a new mock instance.
-func NewMockRoleRepoInterface(ctrl *gomock.Controller) *MockRoleRepoInterface {
-	mock := &MockRoleRepoInterface{ctrl: ctrl}
-	mock.recorder = &MockRoleRepoInterfaceMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRoleRepoInterface) EXPECT() *MockRoleRepoInterfaceMockRecorder {
-	return m.recorder
-}
-
-// GetRoles mocks base method.
-func (m *MockRoleRepoInterface) GetRoles() ([]entity.Role, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRoles")
-	ret0, _ := ret[0].([]entity.Role)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRoles indicates an expected call of GetRoles.
-func (mr *MockRoleRepoInterfaceMockRecorder) GetRoles() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoles", reflect.TypeOf((*MockRoleRepoInterface)(nil).GetRoles))
 }
 
 // MockRoleRepoInterface is a mock of RoleRepoInterface interface.


### PR DESCRIPTION
[Feature] Add GetAllAssets endpoint

This pull request adds a new API endpoint `GET /assets` to retrieve a list of all assets in the system. The `GetAllAssets` endpoint allows clients to fetch information about all available assets, including their codes, issuers, and other relevant details.

The implementation includes the following changes:

1. New `GetAllAssets` route handler in the `assetsRoutes` struct, which retrieves all assets from the database using the `AssetUseCase` interface.
2. Integration of the `GetAllAssets` route handler into the existing Gin router in the `/assets` group.
3. JSON response containing an array of asset objects with their corresponding details.

The addition of the `GetAllAssets` endpoint enhances the asset management capabilities of the application, enabling clients to retrieve a comprehensive list of assets for various purposes such as querying available options or displaying asset information in a user interface.
