### PR TITLE
chore(tfv2-backend): add CA certs to TFV2 Backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,5 @@ WORKDIR /app
 COPY --from=builder /workspace/main .
 COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
 COPY --from=base /workspace/migrations ./migrations
+COPY --from=base /etc/ssl/certs/ /etc/ssl/certs/
 ENTRYPOINT ["./main"]


### PR DESCRIPTION
## What

* Add CA certs to TFV2 Backend

## Why

* We need to call S3 API so we need CA certificates to avoid SSL errors