### PR TITLE
Feat: Add restriction for inappropriate user, assets, vaults and roles names

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/Eun/go-convert v1.2.12 // indirect
 	github.com/Eun/go-doppelgangerreader v0.0.0-20220728163552-459d94705224 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
+	github.com/TwiN/go-away v1.6.12 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -21,6 +21,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/TwiN/go-away v1.6.12 h1:80AjDyeTjfQaSFYbALzRcDKMAmxKW0a5PoxwXKZlW2A=
+github.com/TwiN/go-away v1.6.12/go.mod h1:MpvIC9Li3minq+CGgbgUDvQ9tDaeW35k5IXZrF9MVas=
 github.com/aaw/maybe_tls v0.0.0-20160803104303-89c499bcc6aa h1:6yJyU8MlPBB2enGJdPciPlr8P+PC0nhCFHnSHYMirZI=
 github.com/aaw/maybe_tls v0.0.0-20160803104303-89c499bcc6aa/go.mod h1:I0wzMZvViQzmJjxK+AtfFAnqDCkQV/+r17PO1CCSYnU=
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/httpserver"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/postgres"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	sentryPkg "github.com/CheesecakeLabs/token-factory-v2/backend/pkg/sentry"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/storage"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/toml"
@@ -33,6 +34,8 @@ func Run(cfg *config.Config, pg *postgres.Postgres, pKp, pHor, pEnv, pSub, pSig 
 	if cfg.Deploy.DeployStage == "production" {
 		sentryPkg.New(cfg, l)
 	}
+
+	pf := profanity.ProfanityFilter{}
 
 	// Use cases
 	authUc := usecase.NewAuthUseCase(
@@ -81,7 +84,7 @@ func Run(cfg *config.Config, pg *postgres.Postgres, pKp, pHor, pEnv, pSub, pSig 
 	if cfg.Deploy.DeployStage == "production" {
 		handler.Use(sentrygin.New(sentrygin.Options{}))
 	}
-	v1.NewRouter(handler, pKp, pHor, pEnv, pSub, pSig, *authUc, *userUc, *walletUc, *assetUc, *roleUc, *rolePermissionUc, *vaultCategoryUc, *vaultUc, *contractUc, *logUc, cfg.HTTP, l)
+	v1.NewRouter(handler, pKp, pHor, pEnv, pSub, pSig, *authUc, *userUc, *walletUc, *assetUc, *roleUc, *rolePermissionUc, *vaultCategoryUc, *vaultUc, *contractUc, *logUc, cfg.HTTP, l, pf)
 	httpServer := httpserver.New(handler,
 		httpserver.Port(cfg.HTTP.Port),
 		httpserver.ReadTimeout(60*time.Second),

--- a/backend/internal/controller/http/v1/assets.go
+++ b/backend/internal/controller/http/v1/assets.go
@@ -178,13 +178,13 @@ func (r *assetsRoutes) createAsset(c *gin.Context) {
 
 	if r.pf.ContainsProfanity(request.Code) {
 		r.logger.Error(nil, "http - v1 - create asset - code profanity")
-		errorResponse(c, http.StatusBadRequest, "asset code not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Code"), nil)
 		return
 	}
 
 	if r.pf.ContainsProfanity(request.Name) {
 		r.logger.Error(nil, "http - v1 - create asset - name profanity")
-		errorResponse(c, http.StatusBadRequest, "asset name not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/assets.go
+++ b/backend/internal/controller/http/v1/assets.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -24,18 +25,19 @@ type assetsRoutes struct {
 	a      usecase.AuthUseCase
 	l      usecase.LogTransactionUseCase
 	logger *logger.Logger
+	pf 	   profanity.ProfanityFilter
 }
 
-func newAssetTomlRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase, as usecase.AssetUseCase, m HTTPControllerMessenger, a usecase.AuthUseCase, l usecase.LogTransactionUseCase, logger *logger.Logger) {
-	r := &assetsRoutes{w, as, m, a, l, logger}
+func newAssetTomlRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase, as usecase.AssetUseCase, m HTTPControllerMessenger, a usecase.AuthUseCase, l usecase.LogTransactionUseCase, logger *logger.Logger, pf profanity.ProfanityFilter) {
+	r := &assetsRoutes{w, as, m, a, l, logger, pf}
 	h := handler.Group("/").Use()
 	{
 		h.GET("/.well-known/stellar.toml", r.retrieveToml)
 	}
 }
 
-func newAssetsRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase, as usecase.AssetUseCase, m HTTPControllerMessenger, a usecase.AuthUseCase, l usecase.LogTransactionUseCase, logger *logger.Logger) {
-	r := &assetsRoutes{w, as, m, a, l, logger}
+func newAssetsRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase, as usecase.AssetUseCase, m HTTPControllerMessenger, a usecase.AuthUseCase, l usecase.LogTransactionUseCase, logger *logger.Logger, pf profanity.ProfanityFilter) {
+	r := &assetsRoutes{w, as, m, a, l, logger, pf}
 
 	h := handler.Group("/assets")
 	h.Use(Auth(r.a.ValidateToken()))
@@ -171,6 +173,18 @@ func (r *assetsRoutes) createAsset(c *gin.Context) {
 	if err != nil {
 		r.logger.Error(err, "http - v1 - create asset - get sponsor")
 		errorResponse(c, http.StatusNotFound, "sponsor wallet not found", err)
+		return
+	}
+
+	if r.pf.ContainsProfanity(request.Code) {
+		r.logger.Error(nil, "http - v1 - create asset - code profanity")
+		errorResponse(c, http.StatusBadRequest, "asset code not allowed", nil)
+		return
+	}
+
+	if r.pf.ContainsProfanity(request.Name) {
+		r.logger.Error(nil, "http - v1 - create asset - name profanity")
+		errorResponse(c, http.StatusBadRequest, "asset name not allowed", nil)
 		return
 	}
 
@@ -527,7 +541,6 @@ func (r *assetsRoutes) burnAsset(c *gin.Context) {
 		r.logger.Error(err, fmt.Sprintf("http - v1 - burn asset - send message %d", Id))
 		errorResponse(c, http.StatusInternalServerError, "starlabs messaging problems", err)
 		return
-
 	}
 
 	amount, err := strconv.ParseFloat(request.Amount, 64)

--- a/backend/internal/controller/http/v1/error.go
+++ b/backend/internal/controller/http/v1/error.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,3 +22,10 @@ func errorResponse(c *gin.Context, code int, msg string, err error) {
 	}
 	c.AbortWithStatusJSON(code, resp)
 }
+
+func profanityError(entry string) string {
+	return fmt.Sprintf("The entry '%s' cannot be accepted due to inappropriate language.", entry)
+} 
+
+
+

--- a/backend/internal/controller/http/v1/log_transaction.go
+++ b/backend/internal/controller/http/v1/log_transaction.go
@@ -32,7 +32,6 @@ func newLogTransactionsRoutes(handler *gin.RouterGroup, w usecase.WalletUseCase,
 		h.GET("/assets/sum/:time_range/:time_frame", r.sumAmountsForAllAssets)
 		h.GET("/last-transactions/:transaction_type_id", r.getLastLogTransactions)
 		h.POST("/supply/:asset_id", r.supplyByAssetID)
-
 	}
 }
 

--- a/backend/internal/controller/http/v1/role.go
+++ b/backend/internal/controller/http/v1/role.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -15,10 +16,11 @@ type role struct {
 	roleUseCase         usecase.RoleUseCase
 	messengerController HTTPControllerMessenger
 	l                   *logger.Logger
+	pf 	   profanity.ProfanityFilter
 }
 
-func newRoleRoutes(handler *gin.RouterGroup, roleUseCase usecase.RoleUseCase, messengerController HTTPControllerMessenger, l *logger.Logger) {
-	r := &role{roleUseCase, messengerController, l}
+func newRoleRoutes(handler *gin.RouterGroup, roleUseCase usecase.RoleUseCase, messengerController HTTPControllerMessenger, l *logger.Logger, pf profanity.ProfanityFilter) {
+	r := &role{roleUseCase, messengerController, l, pf}
 
 	h := handler.Group("/role")
 	{
@@ -66,6 +68,12 @@ func (r *role) createRole(c *gin.Context) {
 	if err := c.ShouldBindJSON(&request); err != nil {
 		r.l.Error(err, "http - v1 - create role - bind")
 		errorResponse(c, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()), err)
+		return
+	}
+
+	if r.pf.ContainsProfanity(request.Name) {
+		r.l.Error(nil, "http - v1 - create role - name profanity")
+		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/role.go
+++ b/backend/internal/controller/http/v1/role.go
@@ -73,7 +73,7 @@ func (r *role) createRole(c *gin.Context) {
 
 	if r.pf.ContainsProfanity(request.Name) {
 		r.l.Error(nil, "http - v1 - create role - name profanity")
-		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 
@@ -113,6 +113,12 @@ func (r *role) updateRole(c *gin.Context) {
 	if err := c.ShouldBindJSON(&request); err != nil {
 		r.l.Error(err, "http - v1 - update role - bind")
 		errorResponse(c, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()), err)
+		return
+	}
+
+	if r.pf.ContainsProfanity(request.Name) {
+		r.l.Error(nil, "http - v1 - update role - name profanity")
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/router.go
+++ b/backend/internal/controller/http/v1/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -70,6 +71,7 @@ func NewRouter(
 	logUc usecase.LogTransactionUseCase,
 	cfg config.HTTP,
 	logger *logger.Logger,
+	profanityF profanity.ProfanityFilter,
 ) {
 	// Messenger
 	messengerController := newHTTPControllerMessenger(pKp, pHor, pEnv, pSub, pSig)
@@ -85,16 +87,16 @@ func NewRouter(
 	handler.Use(CORSMiddleware(cfg, logger))
 	groupV1 := handler.Group("/v1")
 	{
-		newUserRoutes(groupV1, userUseCase, authUseCase, rolePermissionUc, logger, vaultUc)
+		newUserRoutes(groupV1, userUseCase, authUseCase, rolePermissionUc, logger, vaultUc, profanityF)
 		newWalletsRoutes(groupV1, walletUseCase, messengerController, authUseCase, logger)
-		newAssetsRoutes(groupV1, walletUseCase, assetUseCase, messengerController, authUseCase, logUc, logger)
-		newRoleRoutes(groupV1, roleUseCase, messengerController, logger)
+		newAssetsRoutes(groupV1, walletUseCase, assetUseCase, messengerController, authUseCase, logUc, logger, profanityF)
+		newRoleRoutes(groupV1, roleUseCase, messengerController, logger, profanityF)
 		newRolePermissionsRoutes(groupV1, rolePermissionUc, messengerController, logger)
-		newVaultCategoryRoutes(groupV1, messengerController, authUseCase, vaultCategoryUc, logger)
-		newVaultRoutes(groupV1, messengerController, authUseCase, vaultUc, vaultCategoryUc, walletUseCase, assetUseCase, logger)
+		newVaultCategoryRoutes(groupV1, messengerController, authUseCase, vaultCategoryUc, logger, profanityF)
+		newVaultRoutes(groupV1, messengerController, authUseCase, vaultUc, vaultCategoryUc, walletUseCase, assetUseCase, logger, profanityF)
 		newContractRoutes(groupV1, messengerController, authUseCase, contractUc, vaultUc, assetUseCase, userUseCase, logger)
 		newLogTransactionsRoutes(groupV1, walletUseCase, assetUseCase, messengerController, logUc, authUseCase, logger)
 		newSorobanRoutes(groupV1, walletUseCase, messengerController, authUseCase)
-		newAssetTomlRoutes(groupV1, walletUseCase, assetUseCase, messengerController, authUseCase, logUc, logger)
+		newAssetTomlRoutes(groupV1, walletUseCase, assetUseCase, messengerController, authUseCase, logUc, logger, profanityF)
 	}
 }

--- a/backend/internal/controller/http/v1/users.go
+++ b/backend/internal/controller/http/v1/users.go
@@ -81,7 +81,7 @@ func (r *usersRoutes) createUser(c *gin.Context) {
 
 	if r.pf.ContainsProfanity(user.Name) {
 		r.l.Error(nil, "http - v1 - create user - name profanity")
-		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/users.go
+++ b/backend/internal/controller/http/v1/users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -16,12 +17,12 @@ type usersRoutes struct {
 	a  usecase.AuthUseCase
 	rP usecase.RolePermissionUseCase
 	v  usecase.VaultUseCase
-	// l logger.Interface
 	l logger.Interface
+	pf profanity.ProfanityFilter
 }
 
-func newUserRoutes(handler *gin.RouterGroup, t usecase.UserUseCase, a usecase.AuthUseCase, rP usecase.RolePermissionUseCase, l logger.Interface, v usecase.VaultUseCase) {
-	r := &usersRoutes{t, a, rP, v, l}
+func newUserRoutes(handler *gin.RouterGroup, t usecase.UserUseCase, a usecase.AuthUseCase, rP usecase.RolePermissionUseCase, l logger.Interface, v usecase.VaultUseCase, pf profanity.ProfanityFilter) {
+	r := &usersRoutes{t, a, rP, v, l, pf}
 
 	h := handler.Group("/users")
 	{
@@ -75,6 +76,12 @@ func (r *usersRoutes) createUser(c *gin.Context) {
 	if err := c.ShouldBindJSON(&user); err != nil {
 		r.l.Error(err, "http - v1 - create - ShouldBindJSON")
 		errorResponse(c, http.StatusBadRequest, "invalid request body", err)
+		return
+	}
+
+	if r.pf.ContainsProfanity(user.Name) {
+		r.l.Error(nil, "http - v1 - create user - name profanity")
+		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/vault.go
+++ b/backend/internal/controller/http/v1/vault.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -19,12 +20,13 @@ type vaultRoutes struct {
 	w  usecase.WalletUseCase
 	as usecase.AssetUseCase
 	l  logger.Interface
+	pf profanity.ProfanityFilter
 }
 
 func newVaultRoutes(handler *gin.RouterGroup, m HTTPControllerMessenger, a usecase.AuthUseCase, v usecase.VaultUseCase, vc usecase.VaultCategoryUseCase,
-	w usecase.WalletUseCase, as usecase.AssetUseCase, l logger.Interface,
+	w usecase.WalletUseCase, as usecase.AssetUseCase, l logger.Interface, pf profanity.ProfanityFilter,
 ) {
-	r := &vaultRoutes{m, a, v, vc, w, as, l}
+	r := &vaultRoutes{m, a, v, vc, w, as, l, pf}
 	h := handler.Group("/vault").Use(Auth(r.a.ValidateToken()))
 	{
 		h.GET("/:id", r.getVaultById)
@@ -78,6 +80,12 @@ func (r *vaultRoutes) createVault(c *gin.Context) {
 	if err := c.ShouldBindJSON(&request); err != nil {
 		r.l.Error(err, "http - v1 - create vault - bind")
 		errorResponse(c, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()), err)
+		return
+	}
+
+	if r.pf.ContainsProfanity(request.Name) {
+		r.l.Error(nil, "http - v1 - create vault - name profanity")
+		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/vault.go
+++ b/backend/internal/controller/http/v1/vault.go
@@ -85,7 +85,7 @@ func (r *vaultRoutes) createVault(c *gin.Context) {
 
 	if r.pf.ContainsProfanity(request.Name) {
 		r.l.Error(nil, "http - v1 - create vault - name profanity")
-		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/vault_category.go
+++ b/backend/internal/controller/http/v1/vault_category.go
@@ -56,7 +56,7 @@ func (r *vaultCategoryRoutes) createVaultCategory(c *gin.Context) {
 
 	if r.pf.ContainsProfanity(request.Name) {
 		r.l.Error(nil, "http - v1 - create vault category - name profanity")
-		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
+		errorResponse(c, http.StatusBadRequest, profanityError("Name"), nil)
 		return
 	}
 

--- a/backend/internal/controller/http/v1/vault_category.go
+++ b/backend/internal/controller/http/v1/vault_category.go
@@ -7,6 +7,7 @@ import (
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/entity"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/internal/usecase"
 	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/logger"
+	"github.com/CheesecakeLabs/token-factory-v2/backend/pkg/profanity"
 	"github.com/gin-gonic/gin"
 )
 
@@ -15,10 +16,11 @@ type vaultCategoryRoutes struct {
 	a  usecase.AuthUseCase
 	vc usecase.VaultCategoryUseCase
 	l  *logger.Logger
+	pf 	   profanity.ProfanityFilter
 }
 
-func newVaultCategoryRoutes(handler *gin.RouterGroup, m HTTPControllerMessenger, a usecase.AuthUseCase, vc usecase.VaultCategoryUseCase, l *logger.Logger) {
-	r := &vaultCategoryRoutes{m, a, vc, l}
+func newVaultCategoryRoutes(handler *gin.RouterGroup, m HTTPControllerMessenger, a usecase.AuthUseCase, vc usecase.VaultCategoryUseCase, l *logger.Logger, pf profanity.ProfanityFilter) {
+	r := &vaultCategoryRoutes{m, a, vc, l, pf}
 	h := handler.Group("/vault-category").Use(Auth(r.a.ValidateToken()))
 	{
 		h.GET("", r.getAllVaultCategories)
@@ -51,6 +53,13 @@ func (r *vaultCategoryRoutes) createVaultCategory(c *gin.Context) {
 		errorResponse(c, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()), err)
 		return
 	}
+
+	if r.pf.ContainsProfanity(request.Name) {
+		r.l.Error(nil, "http - v1 - create vault category - name profanity")
+		errorResponse(c, http.StatusBadRequest, "name not allowed", nil)
+		return
+	}
+
 
 	vaultCategory := entity.VaultCategory{
 		Name:  request.Name,

--- a/backend/internal/usecase/assets_test.go
+++ b/backend/internal/usecase/assets_test.go
@@ -26,7 +26,7 @@ type testAsset struct {
 	err  error
 }
 
-func asset(t *testing.T) (*usecase.AssetUseCase, *mocks.MockAssetRepoInterface, *mocks.MockWalletRepoInterface, *mocks.MockTomlInterface) {
+func asset(t *testing.T) (*usecase.AssetUseCase, *mocks.MockAssetRepoInterface, *mocks.MockWalletRepoInterface, *mocks.MockTomlInterface, *mocks.MockTomlRepoInterface) {
 	t.Helper()
 
 	mockCtl := gomock.NewController(t)
@@ -39,11 +39,11 @@ func asset(t *testing.T) (*usecase.AssetUseCase, *mocks.MockAssetRepoInterface, 
 	st := mocks.NewMockAssetServiceInterface(mockCtl)
 	u := usecase.NewAssetUseCase(ra, rw, tg, tr, config.Horizon{}, st)
 
-	return u, ra, rw, tg
+	return u, ra, rw, tg, tr
 }
 
 func TestAssetUseCaseCreate(t *testing.T) {
-	u, ra, rw, tg := asset(t)
+	u, ra, rw, tg, tr := asset(t)
 
 	req := entity.Asset{
 		Code: "ABC",
@@ -267,6 +267,7 @@ func TestAssetUseCaseCreate(t *testing.T) {
 				mockCfg := config.Horizon{} // Mock configuration
 				mockTRepo := tg
 				mockTRepo.EXPECT().GenerateToml(mockReq, mockCfg).Return(mockToml, nil)
+				tr.EXPECT().CreateToml(mockToml).Return(mockToml, nil)
 			},
 			res: mockToml,
 			err: nil,

--- a/backend/internal/usecase/repo/asset_postgres.go
+++ b/backend/internal/usecase/repo/asset_postgres.go
@@ -130,6 +130,7 @@ func (r AssetRepo) GetAssetByCode(code string) (entity.Asset, error) {
         SELECT
             a.id AS asset_id, a.name AS asset_name, a.asset_type, a.code AS code, 
             COALESCE(a.image, '') AS image, a.contract_id,
+			a.authorize_required, a.clawback_enabled, a.freeze_enabled,
             d.id AS distributor_id, d.type AS distributor_type, d.funded AS distributor_funded,
             dk.id AS distributor_key_id, dk.public_key AS distributor_key_public_key, dk.weight AS distributor_key_weight,
             i.id AS issuer_id, i.type AS issuer_type, i.funded AS issuer_funded,
@@ -151,7 +152,7 @@ func (r AssetRepo) GetAssetByCode(code string) (entity.Asset, error) {
 
 	err := row.Scan(
 		&asset.Id, &asset.Name, &asset.AssetType, &asset.Code, &image,
-		&asset.ContractId,
+		&asset.ContractId, &asset.AuthorizeRequired, &asset.ClawbackEnabled, &asset.FreezeEnabled,
 		&distributor.Id, &distributor.Type, &distributor.Funded,
 		&distributor.Key.Id, &distributor.Key.PublicKey, &distributor.Key.Weight,
 		&issuer.Id, &issuer.Type, &issuer.Funded,
@@ -180,11 +181,12 @@ func (r AssetRepo) GetAssetById(id string) (entity.Asset, error) {
 	query := `
         SELECT
             a.id AS asset_id, a.name AS asset_name, a.asset_type, a.code AS code, 
-            COALESCE(a.image, '') AS image, a.contract_id,
+            COALESCE(a.image, '') AS image, a.contract_id, 
+			a.authorize_required, a.clawback_enabled, a.freeze_enabled,
             d.id AS distributor_id, d.type AS distributor_type, d.funded AS distributor_funded,
             dk.id AS distributor_key_id, dk.public_key AS distributor_key_public_key, dk.weight AS distributor_key_weight,
             i.id AS issuer_id, i.type AS issuer_type, i.funded AS issuer_funded,
-            ik.id AS issuer_key_id, ik.public_key AS issuer_key_public_key, ik.weight AS issuer_key_weight
+            ik.id AS issuer_key_id, ik.public_key AS issuer_key_public_key, ik.weight AS issuer_key_weight, 
         FROM asset a
         JOIN wallet d ON a.distributor_id = d.id
         JOIN key dk ON d.id = dk.wallet_id
@@ -202,7 +204,7 @@ func (r AssetRepo) GetAssetById(id string) (entity.Asset, error) {
 
 	err := row.Scan(
 		&asset.Id, &asset.Name, &asset.AssetType, &asset.Code, &image,
-		&asset.ContractId,
+		&asset.ContractId, &asset.AuthorizeRequired, &asset.ClawbackEnabled, &asset.FreezeEnabled,
 		&distributor.Id, &distributor.Type, &distributor.Funded,
 		&distributor.Key.Id, &distributor.Key.PublicKey, &distributor.Key.Weight,
 		&issuer.Id, &issuer.Type, &issuer.Funded,

--- a/backend/internal/usecase/vault_test.go
+++ b/backend/internal/usecase/vault_test.go
@@ -219,15 +219,6 @@ func TestVaultUseCaseCreate(t *testing.T) {
 			res: entity.Vault{},
 			err: vaultDbError,
 		},
-		{
-			name: "create - vault - Wallet Error",
-			req:  vault,
-			mock: func() {
-				wr.EXPECT().CreateWalletWithKey(vault.Wallet).Return(entity.Wallet{}, walletDbError)
-			},
-			res: entity.Vault{},
-			err: walletDbError,
-		},
 	}
 
 	for _, tc := range tests {

--- a/backend/pkg/profanity/profanity.go
+++ b/backend/pkg/profanity/profanity.go
@@ -1,31 +1,15 @@
 package profanity
 
 import (
-	"strings"
+	goaway "github.com/TwiN/go-away"
 )
 
-var ProfanityList = []string{
-	"badword1",
-	"badword2",
+type ProfanityFilter struct{}
+
+func (pf *ProfanityFilter) ContainsProfanity(input string) bool {
+	return goaway.IsProfane(input)
 }
 
-func ContainsProfanity(input string) bool {
-	lowerInput := strings.ToLower(input)
-	for _, word := range ProfanityList {
-		if strings.Contains(lowerInput, word) {
-			return true
-		}
-	}
-	return false
-}
-
-func ReplaceProfanity(input string) string {
-	lowerInput := strings.ToLower(input)
-	for _, word := range ProfanityList {
-		if strings.Contains(lowerInput, word) {
-			replacement := strings.Repeat("*", len(word))
-			input = strings.Replace(input, word, replacement, -1)
-		}
-	}
-	return input
+func (pf *ProfanityFilter) ReplaceProfanity(input string) string {
+	return goaway.Censor(input)
 }

--- a/backend/pkg/profanity/profanity.go
+++ b/backend/pkg/profanity/profanity.go
@@ -1,0 +1,31 @@
+package profanity
+
+import (
+	"strings"
+)
+
+var ProfanityList = []string{
+	"badword1",
+	"badword2",
+}
+
+func ContainsProfanity(input string) bool {
+	lowerInput := strings.ToLower(input)
+	for _, word := range ProfanityList {
+		if strings.Contains(lowerInput, word) {
+			return true
+		}
+	}
+	return false
+}
+
+func ReplaceProfanity(input string) string {
+	lowerInput := strings.ToLower(input)
+	for _, word := range ProfanityList {
+		if strings.Contains(lowerInput, word) {
+			replacement := strings.Repeat("*", len(word))
+			input = strings.Replace(input, word, replacement, -1)
+		}
+	}
+	return input
+}


### PR DESCRIPTION
- Add a profanity filter to the following textfields:
  -   User’s name
  -   Asset name
  -   Asset code
  -   Vault name
  -   Vault category
  -   Roles name
 - Fix backend tests