### PR TITLE
[DEVOPS-149] chore(backend): add Postgres SSL mode option

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -50,11 +50,13 @@ type (
 	}
 
 	PGConfig struct {
-		Host     string `env-required:"true" env:"PG_HOST"`
-		Port     int    `env-required:"true" env:"PG_PORT"`
-		User     string `env-required:"true" env:"PG_USER"`
-		Password string `env-required:"true" env:"PG_PASSWORD"`
-		DBName   string `env-required:"true" env:"PG_DB_NAME"`
+		Host        string `env-required:"true" env:"PG_HOST"`
+		Port        int    `env-required:"true" env:"PG_PORT"`
+		User        string `env-required:"true" env:"PG_USER"`
+		Password    string `env-required:"true" env:"PG_PASSWORD"`
+		DBName      string `env-required:"true" env:"PG_DB_NAME"`
+		SSLMode     string `env:"PG_SSL_MODE" env-default:"disable"`
+		SSLRootCert string `env:"PG_SSL_ROOT_CERT"`
 	}
 
 	HTTP struct {

--- a/backend/internal/app/migrate.go
+++ b/backend/internal/app/migrate.go
@@ -24,7 +24,10 @@ func init() {
 		log.Fatalf("Config error: %s", e)
 	}
 
-	databaseURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", cfg.PG.User, cfg.PG.Password, cfg.PG.Host, cfg.PG.Port, cfg.PG.DBName)
+	databaseURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s", cfg.PG.User, cfg.PG.Password, cfg.PG.Host, cfg.PG.Port, cfg.PG.DBName, cfg.PG.SSLMode)
+	if cfg.PG.SSLRootCert != "" {
+		databaseURL += fmt.Sprintf("&sslrootcert=%s", cfg.PG.SSLRootCert)
+	}
 
 	var (
 		attempts = _defaultAttempts

--- a/backend/pkg/postgres/postgres.go
+++ b/backend/pkg/postgres/postgres.go
@@ -31,9 +31,12 @@ func New(c config.PGConfig, opts ...Option) (*Postgres, error) {
 	}
 
 	psqlInfo := fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		c.Host, c.Port, c.User, c.Password, c.DBName,
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		c.Host, c.Port, c.User, c.Password, c.DBName, c.SSLMode,
 	)
+	if c.SSLRootCert != "" {
+		psqlInfo += fmt.Sprintf(" sslrootcert=%s", c.SSLRootCert)
+	}
 	var err error
 	for pg.connAttempts > 0 {
 		pg.Db, err = sql.Open("postgres", psqlInfo)


### PR DESCRIPTION
### What
* Add configurable Postgres SSL mode via new `PG_SSL_MODE` env var (defaults to `disable`, preserving current behavior).
* Add optional `PG_SSL_ROOT_CERT` env var to supply a root certificate; appended to the connection string only when set.
* Apply the SSL settings to both the application connection (`backend/pkg/postgres/postgres.go`) and the migration connection (`backend/internal/app/migrate.go`), replacing the previously hardcoded `sslmode=disable`.

### Why
* Allows connecting to Postgres instances that require or verify TLS (e.g. managed RDS with SSL enforcement) without code changes, while keeping the default unchanged for existing environments.

### Ticket
* [DEVOPS-149](https://linear.app/issue/DEVOPS-149)

[DEVOPS-149]: https://cheesecakelabs.atlassian.net/browse/DEVOPS-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ