### PR TITLE
[DEVOPS-149] ci: migrate service deploys from ECS to ECR push

### DIFF
--- a/.github/workflows/backend-cicd.yaml
+++ b/.github/workflows/backend-cicd.yaml
@@ -81,7 +81,7 @@ jobs:
           outputs: type=docker,dest=/tmp/docker_image.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: inputs.run-type == 'Deploy'
         with:
           retention-days: 1
@@ -89,30 +89,26 @@ jobs:
           path: /tmp/docker_image.tar
 
   deploy:
-    name: Deploy
+    name: Push to ECR
     runs-on: ubuntu-latest
     needs: ["code-quality", "build"]
     if: needs.code-quality.result == 'success' && needs.build.result == 'success' && inputs.run-type == 'Deploy'
     environment: Production
     env:
       ECR_REPOSITORY: ${{ vars.resource_base_name }}-tfv2-backend
-      ECS_CLUSTER_NAME: ${{ vars.resource_base_name }}
-      ECS_SERVICE_NAME: ${{ vars.resource_base_name }}-tfv2-backend
-      ECS_CONTAINER_NAME: ${{ vars.resource_base_name }}-tfv2-backend
-      ECS_TASK_NAME: ${{ vars.resource_base_name }}-tfv2-backend
       IMAGE_TAG: ${{ github.sha }}
     permissions:
       contents: "read"
+      id-token: "write"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_BACKEND }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -125,7 +121,7 @@ jobs:
         run: echo "IMAGE=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG )" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker_image
           path: /tmp
@@ -136,24 +132,3 @@ jobs:
           docker tag build:1.0.0 ${{ env.IMAGE }}
           docker image ls -a
           docker push ${{ env.IMAGE }}
-
-      - name: Download ECS task definition
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_NAME --query taskDefinition > task-definition.json
-          cat task-definition.json
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: backend/task-definition.json
-          container-name: ${{ env.ECS_CONTAINER_NAME }}
-          image: ${{ env.IMAGE }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE_NAME }}
-          cluster: ${{ env.ECS_CLUSTER_NAME }}
-          wait-for-service-stability: true

--- a/.github/workflows/frontend-cicd.yaml
+++ b/.github/workflows/frontend-cicd.yaml
@@ -96,7 +96,7 @@ jobs:
           outputs: type=docker,dest=/tmp/docker_image.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: inputs.run-type == 'Deploy'
         with:
           retention-days: 1
@@ -104,30 +104,26 @@ jobs:
           path: /tmp/docker_image.tar
 
   deploy:
-    name: Deploy
+    name: Push to ECR
     runs-on: ubuntu-latest
     needs: ["code-quality", "build"]
     if: needs.code-quality.result == 'success' && needs.build.result == 'success' && inputs.run-type == 'Deploy'
     environment: Production
     env:
       ECR_REPOSITORY: ${{ vars.resource_base_name }}-tfv2-frontend
-      ECS_CLUSTER_NAME: ${{ vars.resource_base_name }}
-      ECS_SERVICE_NAME: ${{ vars.resource_base_name }}-tfv2-frontend
-      ECS_CONTAINER_NAME: ${{ vars.resource_base_name }}-tfv2-frontend
-      ECS_TASK_NAME: ${{ vars.resource_base_name }}-tfv2-frontend
       IMAGE_TAG: ${{ github.sha }}
     permissions:
       contents: "read"
+      id-token: "write"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_FRONTEND }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -140,7 +136,7 @@ jobs:
         run: echo "IMAGE=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG )" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker_image
           path: /tmp
@@ -151,24 +147,3 @@ jobs:
           docker tag build:1.0.0 ${{ env.IMAGE }}
           docker image ls -a
           docker push ${{ env.IMAGE }}
-
-      - name: Download ECS task definition
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_NAME --query taskDefinition > task-definition.json
-          cat task-definition.json
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: frontend/task-definition.json
-          container-name: ${{ env.ECS_CONTAINER_NAME }}
-          image: ${{ env.IMAGE }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE_NAME }}
-          cluster: ${{ env.ECS_CLUSTER_NAME }}
-          wait-for-service-stability: true

--- a/.github/workflows/kms-cicd.yaml
+++ b/.github/workflows/kms-cicd.yaml
@@ -128,7 +128,7 @@ jobs:
           outputs: type=docker,dest=/tmp/docker_image.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         if: inputs.run-type == 'Deploy'
         with:
           retention-days: 1
@@ -136,43 +136,39 @@ jobs:
           path: /tmp/docker_image.tar
 
   deploy:
-    name: Deploy
+    name: Push to ECR
     runs-on: ubuntu-latest
     needs: ['code-quality', 'build']
     if: needs.code-quality.result == 'success' && needs.build.result == 'success' && inputs.run-type == 'Deploy'
     environment: Production
     env:
       ECR_REPOSITORY: ${{ vars.resource_base_name }}-tfv2-kms
-      ECS_CLUSTER_NAME: ${{ vars.resource_base_name }}
-      ECS_SERVICE_NAME: ${{ vars.resource_base_name }}-tfv2-kms
-      ECS_CONTAINER_NAME: ${{ vars.resource_base_name }}-tfv2-kms
-      ECS_TASK_NAME: ${{ vars.resource_base_name }}-tfv2-kms
       IMAGE_TAG: ${{ github.sha }}
     permissions:
       contents: 'read'
+      id-token: 'write'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_KMS }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-        
+
       - name: Set image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: echo "IMAGE=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG )" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: docker_image
           path: /tmp
@@ -183,24 +179,3 @@ jobs:
           docker tag build:1.0.0 ${{ env.IMAGE }}
           docker image ls -a
           docker push ${{ env.IMAGE }}
-          
-      - name: Download ECS task definition
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_NAME --query taskDefinition > task-definition.json
-          cat task-definition.json
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: stellar-kms/task-definition.json
-          container-name: ${{ env.ECS_CONTAINER_NAME }}
-          image: ${{ env.IMAGE }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE_NAME }}
-          cluster: ${{ env.ECS_CLUSTER_NAME }}
-          wait-for-service-stability: true

--- a/.github/workflows/starlabs-cicd.yaml
+++ b/.github/workflows/starlabs-cicd.yaml
@@ -128,7 +128,7 @@ jobs:
           outputs: type=docker,dest=/tmp/docker_image.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         if: inputs.run-type == 'Deploy'
         with:
           retention-days: 1
@@ -136,43 +136,39 @@ jobs:
           path: /tmp/docker_image.tar
 
   deploy:
-    name: Deploy
+    name: Push to ECR
     runs-on: ubuntu-latest
     needs: ['code-quality', 'build']
     if: needs.code-quality.result == 'success' && needs.build.result == 'success' && inputs.run-type == 'Deploy'
     environment: Production
     env:
       ECR_REPOSITORY: ${{ vars.resource_base_name }}-tfv2-starlabs
-      ECS_CLUSTER_NAME: ${{ vars.resource_base_name }}
-      ECS_SERVICE_NAME: ${{ vars.resource_base_name }}-tfv2-starlabs
-      ECS_CONTAINER_NAME: ${{ vars.resource_base_name }}-tfv2-starlabs
-      ECS_TASK_NAME: ${{ vars.resource_base_name }}-tfv2-starlabs
       IMAGE_TAG: ${{ github.sha }}
     permissions:
       contents: 'read'
+      id-token: 'write'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ vars.AWS_ROLE_STARLABS }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-        
+
       - name: Set image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: echo "IMAGE=$(echo $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG )" >> $GITHUB_ENV
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: docker_image
           path: /tmp
@@ -183,24 +179,3 @@ jobs:
           docker tag build:1.0.0 ${{ env.IMAGE }}
           docker image ls -a
           docker push ${{ env.IMAGE }}
-          
-      - name: Download ECS task definition
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_NAME --query taskDefinition > task-definition.json
-          cat task-definition.json
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: starlabs/task-definition.json
-          container-name: ${{ env.ECS_CONTAINER_NAME }}
-          image: ${{ env.IMAGE }}
-
-      - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.ECS_SERVICE_NAME }}
-          cluster: ${{ env.ECS_CLUSTER_NAME }}
-          wait-for-service-stability: true


### PR DESCRIPTION
### What
* Remove ECS task-definition deploy steps from all four service pipelines (backend, frontend, kms, starlabs) so they only build and push images to ECR — EKS pulls from there.
* Switch AWS authentication from static access keys to OIDC `role-to-assume`, using a per-service `AWS_ROLE_*` variable within the shared GitHub environment.
* Bump `actions/upload-artifact` to v7 and `actions/download-artifact` to v8.

### Why
* Part of the ECS → EKS migration: CI/CD is now only responsible for publishing images to ECR; deployment is handled by EKS.
* OIDC removes long-lived static credentials from the pipelines.
* The retired v3 artifact actions were breaking the kms and starlabs runs.

### Ticket
* [DEVOPS-149](https://cheesecakelabs.atlassian.net/browse/DEVOPS-149)

[DEVOPS-149]: https://cheesecakelabs.atlassian.net/browse/DEVOPS-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ